### PR TITLE
Docs: Replace boilerplate Lanyon README with blog documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,134 +1,81 @@
-# Lanyon
+# DataManiac
 
-Lanyon is an unassuming [Jekyll](http://jekyllrb.com) theme that places content first by tucking away navigation in a hidden drawer. It's based on [Poole](http://getpoole.com), the Jekyll butler.
+A personal blog by Zhi Yuan Chua covering football analytics, data science, and the occasional drone video.
 
-![Lanyon](https://f.cloud.github.com/assets/98681/1825266/be03f014-71b0-11e3-9539-876e61530e24.png)
-![Lanyon with open sidebar](https://f.cloud.github.com/assets/98681/1825267/be04a914-71b0-11e3-966f-8afe9894c729.png)
+**Live site:** https://chuazy94.github.io/zy_blog_2
 
-
-## Contents
-
-- [Usage](#usage)
-- [Options](#options)
-  - [Sidebar menu](#sidebar-menu)
-  - [Themes](#themes)
-  - [Reverse layout](#reverse-layout)
-- [Development](#development)
-- [Author](#author)
-- [License](#license)
-
-
-## Usage
-
-Lanyon is a theme built on top of [Poole](https://github.com/poole/poole), which provides a fully furnished Jekyll setup—just download and start the Jekyll server. See [the Poole usage guidelines](https://github.com/poole/poole#usage) for how to install and use Jekyll.
-
-
-## Options
-
-Lanyon includes some customizable options, typically applied via classes on the `<body>` element.
-
-
-### Sidebar menu
-
-Create a list of nav links in the sidebar by assigning each Jekyll page the correct layout in the page's [front-matter](http://jekyllrb.com/docs/frontmatter/).
-
-```
 ---
-layout: page
-title: About
+
+## About
+
+DataManiac was started during the COVID-19 pandemic out of a mix of boredom and curiosity. Posts explore:
+
+- Football analytics (xG models, tournament simulators, match predictions)
+- Data science methods (Poisson modelling, GEE, Elo ratings)
+- Drone videography
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Static site generator | [Jekyll](https://jekyllrb.com/) 4.3+ |
+| Theme | [Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/) 4.26.2 (remote theme) |
+| Hosting | GitHub Pages |
+| CI/CD | GitHub Actions (auto-deploy on push to `main`) |
+| Markdown processor | kramdown + Rouge syntax highlighting |
+
+---
+
+## Local Development
+
+**Requirements:** Ruby 3.x, Bundler
+
+```bash
+# Install dependencies
+bundle install
+
+# Serve locally with live reload
+bundle exec jekyll serve
+
+# Visit the site
+open http://localhost:4000/zy_blog_2
+```
+
+Changes to `_posts/`, `_config.yml`, and layout files are picked up automatically. A full restart is required after editing `_config.yml`.
+
+---
+
+## Writing a New Post
+
+Create a file in `_posts/` following the naming convention `YYYY-MM-DD-slug.md`.
+
+Frontmatter template:
+
+```yaml
+---
+layout: single
+title: "Your Post Title"
+date: YYYY-MM-DD
+description: "A one-sentence summary for SEO and social sharing."
+tags: [football-analytics, data-science]
+categories: [football]
+author_profile: true
+read_time: true
 ---
 ```
 
-**Why require a specific layout?** Jekyll will return *all* pages, including the `atom.xml`, and with an alphabetical sort order. To ensure the first link is *Home*, we exclude the `index.html` page from this list by specifying the `page` layout.
+The `layout: single` and `author_profile: true` fields are set as defaults in `_config.yml`, so they can be omitted if you do not need to override them.
 
+---
 
-### Themes
+## Deployment
 
-Lanyon ships with eight optional themes based on the [base16 color scheme](https://github.com/chriskempson/base16). Apply a theme to change the color scheme (mostly applies to sidebar and links).
+Pushing to the `main` branch triggers a GitHub Actions workflow that builds the Jekyll site and deploys it to GitHub Pages automatically. No manual steps are required.
 
-![Lanyon with red theme](https://f.cloud.github.com/assets/98681/1825270/be065110-71b0-11e3-9ed8-9b8de753a4af.png)
-![Lanyon with red theme and open sidebar](https://f.cloud.github.com/assets/98681/1825269/be05ec20-71b0-11e3-91ea-a9138ef07186.png)
-
-There are eight themes available at this time.
-
-![Available theme classes](https://f.cloud.github.com/assets/98681/1817044/e5b0ec06-6f68-11e3-83d7-acd1942797a1.png)
-
-To use a theme, add any one of the available theme classes to the `<body>` element in the `default.html` layout, like so:
-
-```html
-<body class="theme-base-08">
-  ...
-</body>
-```
-
-To create your own theme, look to the Themes section of [included CSS file](https://github.com/poole/lanyon/blob/master/public/css/lanyon.css). Copy any existing theme (they're only a few lines of CSS), rename it, and change the provided colors.
-
-
-### Reverse layout
-
-![Lanyon with reverse layout](https://f.cloud.github.com/assets/98681/1825265/be03f2e4-71b0-11e3-89f1-360705524495.png)
-![Lanyon with reverse layout and open sidebar](https://f.cloud.github.com/assets/98681/1825268/be056174-71b0-11e3-88c8-5055bca4307f.png)
-
-Reverse the page orientation with a single class.
-
-```html
-<body class="layout-reverse">
-  ...
-</body>
-```
-
-
-### Sidebar overlay instead of push
-
-Make the sidebar overlap the viewport content with a single class:
-
-```html
-<body class="sidebar-overlay">
-  ...
-</body>
-```
-
-This will keep the content stationary and slide in the sidebar over the side content. It also adds a `box-shadow` based outline to the toggle for contrast against backgrounds, as well as a `box-shadow` on the sidebar for depth.
-
-It's also available for a reversed layout when you add both classes:
-
-```html
-<body class="layout-reverse sidebar-overlay">
-  ...
-</body>
-```
-
-### Sidebar open on page load
-
-Show an open sidebar on page load by modifying the `<input>` tag within the `sidebar.html` layout to add the `checked` boolean attribute:
-
-```html
-<input type="checkbox" class="sidebar-checkbox" id="sidebar-checkbox" checked>
-```
-
-Using Liquid you can also conditionally show the sidebar open on a per-page basis. For example, here's how you could have it open on the homepage only:
-
-```html
-<input type="checkbox" class="sidebar-checkbox" id="sidebar-checkbox" {% if page.title =="Home" %}checked{% endif %}>
-```
-
-## Development
-
-Lanyon has two branches, but only one is used for active development.
-
-- `master` for development.  **All pull requests should be to submitted against `master`.**
-- `gh-pages` for our hosted site, which includes our analytics tracking code. **Please avoid using this branch.**
-
-
-## Author
-
-**Mark Otto**
-- <https://github.com/mdo>
-- <https://twitter.com/mdo>
-
+---
 
 ## License
 
-Open sourced under the [MIT license](LICENSE.md).
-
-<3
+Blog content (posts and images) is copyright Zhi Yuan Chua. The underlying Jekyll theme ([Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes)) is MIT licensed.


### PR DESCRIPTION
- Describes the DataManiac blog, its purpose and tech stack
- Adds local development setup instructions
- Documents frontmatter for writing new posts
- Explains automated GitHub Actions deployment